### PR TITLE
feat: rename to felt252

### DIFF
--- a/src/math/u256.cairo
+++ b/src/math/u256.cairo
@@ -1,13 +1,13 @@
 //! Missing corelib trait implementations for u256.
 
-use array::ArrayTrait;     
+use array::ArrayTrait;
 use zeroable::Zeroable;
 
 /// Canonical implementation of Zeroable for u256.
 impl U256Zeroable of Zeroable::<u256> {
     #[inline(always)]
     fn zero() -> u256 {
-        u256{low: 0_u128, high: 0_u128}
+        u256 { low: 0_u128, high: 0_u128 }
     }
 
     #[inline(always)]
@@ -29,7 +29,7 @@ impl U256Zeroable of Zeroable::<u256> {
 impl U256TruncatedDiv of Div::<u256> {
     fn div(a: u256, b: u256) -> u256 {
         assert(a.high == 0_u128 & b.high == 0_u128, 'u256 too large');
-        u256{low: a.low / b.low, high: 0_u128}
+        u256 { low: a.low / b.low, high: 0_u128 }
     }
 }
 
@@ -45,7 +45,7 @@ impl U256TruncatedDivEq of DivEq::<u256> {
 impl U256TruncatedRem of Rem::<u256> {
     fn rem(a: u256, b: u256) -> u256 {
         assert(a.high == 0_u128 & b.high == 0_u128, 'u256 too large');
-        u256{low: a.low % b.low, high: 0_u128}
+        u256 { low: a.low % b.low, high: 0_u128 }
     }
 }
 

--- a/src/math/u60f18.cairo
+++ b/src/math/u60f18.cairo
@@ -24,7 +24,9 @@ fn mul_div_down(a: u256, b: u256, denominator: u256) -> u256 {
     // let max_u256 = u256{low: max_u128, high: max_u128};
     // TODO: Change this back when u256 non-truncating division is implemented
     let max_u256 = 0xffffffffffffffffffffffffffffffff.into();
-    let cond = U256Zeroable::is_non_zero(denominator) & (U256Zeroable::is_zero(b) | a <= max_u256 / b);
+    let cond = U256Zeroable::is_non_zero(
+        denominator
+    ) & (U256Zeroable::is_zero(b) | a <= max_u256 / b);
     assert(cond, 'multiplication overflow');
     a * b / denominator
 }
@@ -44,7 +46,9 @@ impl U256MulDiv of MulDiv::<u256> {
         let result = mul_div_down(a, b, denominator);
         match rounding {
             Rounding::Down(_) => result,
-            Rounding::Up(_) => if unsafe_mul_mod(a, b, denominator) > 0.into() {
+            Rounding::Up(_) => if unsafe_mul_mod(
+                a, b, denominator
+            ) > 0.into() {
                 result + 1.into()
             } else {
                 result
@@ -66,7 +70,7 @@ struct U60F18 {
 
 impl U60F18Add of Add::<U60F18> {
     fn add(a: U60F18, b: U60F18) -> U60F18 {
-        U60F18{scaled: a.scaled + b.scaled}
+        U60F18 { scaled: a.scaled + b.scaled }
     }
 }
 
@@ -79,7 +83,7 @@ impl U60F18AddEq of AddEq::<U60F18> {
 
 impl U60F18Sub of Sub::<U60F18> {
     fn sub(a: U60F18, b: U60F18) -> U60F18 {
-        U60F18{scaled: a.scaled - b.scaled}
+        U60F18 { scaled: a.scaled - b.scaled }
     }
 }
 
@@ -93,7 +97,7 @@ impl U60F18SubEq of SubEq::<U60F18> {
 impl U60F18Mul of Mul::<U60F18> {
     fn mul(a: U60F18, b: U60F18) -> U60F18 {
         let base: u256 = 1000000000000000000.into();
-        U60F18{scaled: mul_div_down(a.scaled, b.scaled, base)}
+        U60F18 { scaled: mul_div_down(a.scaled, b.scaled, base) }
     }
 }
 
@@ -107,7 +111,7 @@ impl U60F18MulEq of MulEq::<U60F18> {
 impl U60F18Div of Div::<U60F18> {
     fn div(a: U60F18, b: U60F18) -> U60F18 {
         let base: u256 = 1000000000000000000.into();
-        U60F18{scaled: mul_div_down(a.scaled, base, b.scaled)}
+        U60F18 { scaled: mul_div_down(a.scaled, base, b.scaled) }
     }
 }
 
@@ -158,12 +162,12 @@ impl U60F18ToU256 of Into::<U60F18, u256> {
 impl U256ToU60F18 of Into::<u256, U60F18> {
     fn into(self: u256) -> U60F18 {
         let base: u256 = 1000000000000000000.into();
-        U60F18{scaled: self * base}
+        U60F18 { scaled: self * base }
     }
 }
 
-impl FeltToU60F18 of Into::<felt, U60F18> {
-    fn into(self: felt) -> U60F18 {
+impl Felt252ToU60F18 of Into::<felt252, U60F18> {
+    fn into(self: felt252) -> U60F18 {
         let a: u256 = self.into();
         a.into()
     }
@@ -174,5 +178,5 @@ impl U60F18PrintImpl of PrintTrait::<U60F18> {
         self.scaled.print();
     }
 }
-
 // TODO: Implement StorageAccess once it's testable
+

--- a/src/test/u256_test.cairo
+++ b/src/test/u256_test.cairo
@@ -11,29 +11,29 @@ use suna::math::u256::U256Zeroable;
 
 #[test]
 fn test_u256_zeroable() {
-    assert(U256Zeroable::zero() == u256{low: 0_u128, high: 0_u128}, 'zero() error');
-    assert(U256Zeroable::is_zero(u256{low: 0_u128, high: 0_u128}), 'is_zero error');
-    assert(!U256Zeroable::is_zero(u256{low: 1_u128, high: 0_u128}), 'is_zero error');
-    assert(!U256Zeroable::is_zero(u256{low: 0_u128, high: 1_u128}), 'is_zero error');
-    assert(!U256Zeroable::is_non_zero(u256{low: 0_u128, high: 0_u128}), 'is_non_zero error');
-    assert(U256Zeroable::is_non_zero(u256{low: 1_u128, high: 0_u128}), 'is_non_zero error');
-    assert(U256Zeroable::is_non_zero(u256{low: 0_u128, high: 1_u128}), 'is_non_zero error');
+    assert(U256Zeroable::zero() == u256 { low: 0_u128, high: 0_u128 }, 'zero() error');
+    assert(U256Zeroable::is_zero(u256 { low: 0_u128, high: 0_u128 }), 'is_zero error');
+    assert(!U256Zeroable::is_zero(u256 { low: 1_u128, high: 0_u128 }), 'is_zero error');
+    assert(!U256Zeroable::is_zero(u256 { low: 0_u128, high: 1_u128 }), 'is_zero error');
+    assert(!U256Zeroable::is_non_zero(u256 { low: 0_u128, high: 0_u128 }), 'is_non_zero error');
+    assert(U256Zeroable::is_non_zero(u256 { low: 1_u128, high: 0_u128 }), 'is_non_zero error');
+    assert(U256Zeroable::is_non_zero(u256 { low: 0_u128, high: 1_u128 }), 'is_non_zero error');
 }
 
-fn t_trunc_div_rem(a: felt, b: felt) {
+fn t_trunc_div_rem(a: felt252, b: felt252) {
     let a1: u128 = a.try_into().unwrap();
     let b1: u128 = b.try_into().unwrap();
     let a2: u256 = a.into();
     let b2: u256 = b.into();
-    assert(u256{low: a1 / b1, high: 0_u128} == a2 / b2, 'div error');
-    assert(u256{low: a1 % b1, high: 0_u128} == a2 % b2, 'rem error');
+    assert(u256 { low: a1 / b1, high: 0_u128 } == a2 / b2, 'div error');
+    assert(u256 { low: a1 % b1, high: 0_u128 } == a2 % b2, 'rem error');
 
     let mut x = a2;
     x /= b2;
     let mut y = a2;
     y %= b2;
-    assert(u256{low: a1 / b1, high: 0_u128} == x, 'div_eq error');
-    assert(u256{low: a1 % b1, high: 0_u128} == y, 'rem_eq error');
+    assert(u256 { low: a1 / b1, high: 0_u128 } == x, 'div_eq error');
+    assert(u256 { low: a1 % b1, high: 0_u128 } == y, 'rem_eq error');
 }
 
 #[test]

--- a/src/test/u60f18_test.cairo
+++ b/src/test/u60f18_test.cairo
@@ -1,7 +1,7 @@
 use debug::PrintTrait;
 use traits::Into;
 
-use suna::math::u60f18::FeltToU60F18;
+use suna::math::u60f18::Felt252ToU60F18;
 use suna::math::u60f18::Rounding;
 use suna::math::u60f18::U256MulDiv;
 use suna::math::u60f18::U256ToU60F18;
@@ -14,12 +14,12 @@ use suna::math::u60f18::U60F18PartialOrd;
 use suna::math::u60f18::U60F18PrintImpl;
 use suna::math::u60f18::U60F18ToU256;
 
-fn t_mul_div_down(a: felt, b: felt, denominator: felt, expected: felt) {
+fn t_mul_div_down(a: felt252, b: felt252, denominator: felt252, expected: felt252) {
     let result = U256MulDiv::mul_div(a.into(), b.into(), denominator.into(), Rounding::Down(()));
     assert(result == expected.into(), 'mul_div invalid');
 }
 
-fn t_mul_div_up(a: felt, b: felt, denominator: felt, expected: felt) {
+fn t_mul_div_up(a: felt252, b: felt252, denominator: felt252, expected: felt252) {
     let result = U256MulDiv::mul_div(a.into(), b.into(), denominator.into(), Rounding::Up(()));
     assert(result == expected.into(), 'mul_div invalid');
 }
@@ -45,13 +45,13 @@ fn test_mul_div_up() {
 }
 
 #[test]
-#[should_panic(expected = ('multiplication overflow',))]
+#[should_panic(expected = ('multiplication overflow', ))]
 fn test_mul_div_down_failed() {
     U256MulDiv::mul_div(1.into(), 1.into(), 0.into(), Rounding::Down(()));
 }
 
 #[test]
-#[should_panic(expected = ('multiplication overflow',))]
+#[should_panic(expected = ('multiplication overflow', ))]
 fn test_mul_div_up_failed() {
     U256MulDiv::mul_div(1.into(), 1.into(), 0.into(), Rounding::Up(()));
 }


### PR DESCRIPTION
This pr aims to do the following
- Renames `felt` to `felt252`
- Fix #1 

Note: Uses this version of scarb and cairo
  ```
  scarb 0.1.0-rc.2 (8e8d51d80 2023-03-20)
  cairo: 1.0.0-alpha.6
  ```
![image](https://user-images.githubusercontent.com/35031356/226875527-f1203633-0851-4d4e-a6af-c7b7bf5a11fd.png)
